### PR TITLE
Remove 'empovit' from OWNERS file

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,7 +1,6 @@
 # See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
 
 approvers:
-  - empovit
   - asm582
   - tardieu
   - harche
@@ -12,7 +11,6 @@ approvers:
   - cpmeadors
   - rphillips
 reviewers:
-  - empovit
   - asm582
   - tardieu
   - harche


### PR DESCRIPTION
Removed 'empovit' from both approvers and reviewers lists.