### PR TITLE
OCPNODE-4184: Update bundle SHA for OCP 4.18-4.21 prod releases

### DIFF
--- a/v4.18/catalog-template.yaml
+++ b/v4.18/catalog-template.yaml
@@ -3,4 +3,4 @@ GenerateMajorChannels: true
 GenerateMinorChannels: false
 Stable:
   Bundles:
-  - Image: registry.redhat.io/dynamic-accelerator-slicer-tech-preview/instaslice-operator-bundle@sha256:309de603ad4198f14331639d22e462e81499870b18a4550308c97ac34af3bf3f
+  - Image: registry.redhat.io/dynamic-accelerator-slicer-tech-preview/instaslice-operator-bundle@sha256:38c2a4e3a437a64bc88e059b3229890432cc7945377e8b943a6e9cb835a82bdf

--- a/v4.18/catalog/instaslice-operator/catalog.json
+++ b/v4.18/catalog/instaslice-operator/catalog.json
@@ -17,7 +17,7 @@
     "schema": "olm.bundle",
     "name": "das-operator.v0.1.0",
     "package": "das-operator",
-    "image": "registry.redhat.io/dynamic-accelerator-slicer-tech-preview/instaslice-operator-bundle@sha256:309de603ad4198f14331639d22e462e81499870b18a4550308c97ac34af3bf3f",
+    "image": "registry.redhat.io/dynamic-accelerator-slicer-tech-preview/instaslice-operator-bundle@sha256:38c2a4e3a437a64bc88e059b3229890432cc7945377e8b943a6e9cb835a82bdf",
     "properties": [
         {
             "type": "olm.gvk",
@@ -57,8 +57,8 @@
                     "alm-examples": "[\n  {\n    \"apiVersion\": \"inference.redhat.com/v1alpha1\",\n    \"kind\": \"DASOperator\",\n    \"metadata\": {\n      \"name\": \"cluster\",\n      \"namespace\": \"das-operator\"\n    },\n    \"spec\": {\n      \"logLevel\": \"Normal\",\n      \"managementState\": \"Managed\",\n      \"operatorLogLevel\": \"Normal\"\n    }\n  }\n]",
                     "capabilities": "Basic Install",
                     "categories": "Drivers and plugins",
-                    "containerImage": "registry.redhat.io/dynamic-accelerator-slicer-tech-preview/instaslice-rhel9-operator@sha256:814ac0501733d971084ae29559132d582adb02736421bd9a97df740976c97896",
-                    "createdAt": "2025-08-13T12:06:16Z",
+                    "containerImage": "registry.redhat.io/dynamic-accelerator-slicer-tech-preview/instaslice-rhel9-operator@sha256:c588c7a1612c944e8b95b3d166c1de46d100fb16ae95641121ddb07fade541a7",
+                    "createdAt": "2026-03-13T23:31:57Z",
                     "description": "Dynamic Accelerator Slicer works with GPU operator to create mig slices on demand",
                     "features.operators.openshift.io/cnf": "false",
                     "features.operators.openshift.io/cni": "false",
@@ -66,13 +66,13 @@
                     "features.operators.openshift.io/disconnected": "false",
                     "features.operators.openshift.io/fips-compliant": "false",
                     "features.operators.openshift.io/proxy-aware": "false",
-                    "features.operators.openshift.io/tls-profiles": "false",
+                    "features.operators.openshift.io/tls-profiles": "true",
                     "features.operators.openshift.io/token-auth-aws": "false",
                     "features.operators.openshift.io/token-auth-azure": "false",
                     "features.operators.openshift.io/token-auth-gcp": "false",
                     "operatorframework.io/suggested-namespace": "das-operator",
                     "operators.openshift.io/valid-subscription": "[\"OpenShift Kubernetes Engine\", \"OpenShift Container Platform\", \"OpenShift Platform Plus\"]",
-                    "operators.operatorframework.io/builder": "operator-sdk-v1.41.1",
+                    "operators.operatorframework.io/builder": "operator-sdk-unknown",
                     "operators.operatorframework.io/project_layout": "go.kubebuilder.io/v4",
                     "repository": "https://github.com/openshift/instaslice-operator",
                     "support": "https://github.com/openshift/instaslice-operator/issues"
@@ -83,21 +83,24 @@
                         {
                             "name": "dasoperators.inference.redhat.com",
                             "version": "v1alpha1",
-                            "kind": "DASOperator"
+                            "kind": "DASOperator",
+                            "description": "DASOperator is the schema for the DASOperator API"
                         },
                         {
                             "name": "allocationclaims.inference.redhat.com",
                             "version": "v1alpha1",
-                            "kind": "AllocationClaim"
+                            "kind": "AllocationClaim",
+                            "description": "AllocationClaim is the schema for GPU slice allocation custom resource."
                         },
                         {
                             "name": "nodeaccelerators.inference.redhat.com",
                             "version": "v1alpha1",
-                            "kind": "NodeAccelerator"
+                            "kind": "NodeAccelerator",
+                            "description": "NodeAccelerator is the schema for the nodeaccelerators API"
                         }
                     ]
                 },
-                "description": "### Introduction\nDynamic Accelerator Slicer uses stable APIs and works with GPU operator to create mig slices on demand.\n\n### Prerequisites\n\n1. Install the [NVIDIA GPU drivers and CUDA toolkit](https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html#driver-installation) on the host.\n2. Install the [NVIDIA Container Toolkit (CTK)](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html).\n3. Configure the NVIDIA Container Runtime as the default Docker runtime:\n      `sudo nvidia-ctk runtime configure --runtime=docker --set-as-default`\n4. Restart Docker to apply the changes:\n      `sudo systemctl restart docker`\n5. Configure the NVIDIA Container Runtime to use volume mounts to select devices to inject into a container:\n      `sudo nvidia-ctk config --set accept-nvidia-visible-devices-as-volume-mounts=true --in-place`\n      This sets accept-nvidia-visible-devices-as-volume-mounts=true in the /etc/nvidia-container-runtime/config.toml file\n6. Enable MIG on the GPU\n      Check if MIG is enabled on the host GPU - look for Enabled in the third row of the nvidia GPU table, while running `nvidia-smi`\n7. Create symlink in the control-plane container\n      `docker exec -ti kind-control-plane ln -s /sbin/ldconfig /sbin/ldconfig.real`\n8. Unmount the nvidia devices in the control-plane container\n      `docker exec -ti kind-control-plane umount -R /proc/driver/nvidia`\n9. Install the GPU Operator\n      `helm upgrade --install --wait gpu-operator -n gpu-operator --create-namespace nvidia/gpu-operator \\\n        --set mig.strategy=mixed \\\n        --set cdi.enabled=true \\\n        --set migManager.enabled=false \\\n        --set migManager.config.default=\"\"`\n10. Deploy cert manager\n      `kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.15.3/cert-manager.yaml`\n      \n### API Backward Compatibility\n**NOTE:**  Until Operator supports **seamless upgrades**, a new version of\nthe operator may introduce a change that is **NOT** backwards compatible with\nthe previous version. Thus, to upgrade the operator, uninstall the already\ninstalled version completely (including CRDs) and install the new version.\nFor example to upgrade from 0.1.0 to 0.2.0, you must uninstall `0.1.0` by\nfollowing [uninstall operator section](https://github.com/openshift/instaslice-operator)\nand install the new version.\n\nChanges to patch version (major.minor.patch) indicates that no breaking changes\nare introduced, thus upgrade can be done without uninstalling and reinstalling\nthe operator.\n\n### Why Dynamic Accelerator Slicer\n\nPartitionable accelerators provided by vendors need partition to be created at node boot-time or to change partitions one would have to evict all the workloads at the node level to create new set of partitions.\n\nDynamic Accelerator Slicer will help if:\n\n- user does not know all the accelerators partitions needed a priori on every node on the cluster\n\n- user partition requirements change at the workload level rather than the node level\n\n- user does not want to learn or use new API to request accelerators slices\n\n- user prefers to use stable device plugins APIs for creating partitions\n\n###Features Overview\n\n- Integration with Kubernetes [quota management](https://github.com/openshift/instaslice-operator/blob/main/docs/instaslice_kube_quota_int.md)\n\n- Integration with project [Kueue](https://github.com/openshift/instaslice-operator/blob/main/docs/kueue.md)\n\n- [Emulator](https://github.com/openshift/instaslice-operator/blob/main/docs/emulator.md) mode to run test Dynamic Accelerator Slicer firstfit placement strategy\n\n- Integration with vLLM, Kserve, [Deployments](https://github.com/openshift/instaslice-operator/blob/main/samples/vllm_deployment.yaml), [Jobs](https://github.com/openshift/instaslice-operator/blob/main/samples/vllm_job.yaml), and [Statefulsets](https://github.com/openshift/instaslice-operator/blob/main/samples/vllm_statefulset.yaml)\n\n### Documentation\nDocumentation and installation guide can be found below:\n  * [Installation Guide](https://github.com/openshift/instaslice-operator)\n  * [Dynamic Accelerator Slicer Operator](https://github.com/openshift/instaslice-operator/blob/main/README.md)\n\n### License\ndas-operator is licensed under the Apache 2.0 license",
+                "description": "### Introduction\nDynamic Accelerator Slicer uses stable APIs and works with the NVIDIA GPU Operator to create MIG slices on demand.\n\n### Why Dynamic Accelerator Slicer\n\nPartitionable accelerators provided by vendors need partition to be created at node boot-time or to change partitions one would have to evict all the workloads at the node level to create new set of partitions.\n\nDynamic Accelerator Slicer will help if:\n\n- user does not know all the accelerators partitions needed a priori on every node on the cluster\n- user partition requirements change at the workload level rather than the node level\n- user does not want to learn or use new API to request accelerators slices\n- user prefers to use stable device plugins APIs for creating partitions\n\n### Features\n- Integration with vLLM, Kserve, [Deployments](https://github.com/openshift/instaslice-operator/blob/main/samples/vllm_deployment.yaml), [Jobs](https://github.com/openshift/instaslice-operator/blob/main/samples/vllm_job.yaml), and [Statefulsets](https://github.com/openshift/instaslice-operator/blob/main/samples/vllm_statefulset.yaml)\n\n### Prerequisites\n\n1. Install the cert-manager Operator for Red Hat OpenShift.\n2. Install the Node Feature Discovery (NFD) Operator and create a NodeFeatureDiscovery custom resource so GPU labels are present on the cluster nodes.\n3. Install the NVIDIA GPU Operator and configure MIG support as described in the product documentation. At a minimum:\n   - Apply a ClusterPolicy that enables MIG mode and disables the default NVIDIA device plugin on nodes where you plan to create slices.\n   - Enable MIG on each GPU (verify with `nvidia-smi` and ensure the MIG column reports `Enabled`).\n   - Confirm the GPU Operator is healthy: `oc get clusterpolicies.nvidia.com -o jsonpath='{.items[0].status.state}'`.\n\nRefer to the OpenShift documentation for the full workflow: https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/html/hardware_accelerators/das-about-dynamic-accelerator-slicer-operator#das-operator-installing-web-console_das-about-dynamic-accelerator-slicer-operator.\n\n### API Backward Compatibility\n**NOTE:** Until Operator supports **seamless upgrades**, a new version of the operator may introduce a change that is **NOT** backwards compatible with the previous version. Thus, to upgrade the operator, uninstall the already installed version completely (including CRDs) and install the new version.\n\nFor example to upgrade from 0.1.0 to 0.2.0, you must uninstall `0.1.0` by following [uninstall operator section](https://github.com/openshift/instaslice-operator) and install the new version.\n\nChanges to patch version (major.minor.patch) indicates that no breaking changes are introduced, thus upgrade can be done without uninstalling and reinstalling the operator.\n\n### Documentation\nDocumentation and installation guide can be found below:\n  * [Dynamic Accelerator Slicer Operator](https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/html/hardware_accelerators/das-about-dynamic-accelerator-slicer-operator#das-operator-installing-web-console_das-about-dynamic-accelerator-slicer-operator)\n\n### License\ndas-operator is licensed under the Apache 2.0 license",
                 "displayName": "Dynamic Accelerator Slicer",
                 "installModes": [
                     {
@@ -181,23 +184,23 @@
     "relatedImages": [
         {
             "name": "daemonset-image",
-            "image": "registry.redhat.io/dynamic-accelerator-slicer-tech-preview/instaslice-daemonset-rhel9@sha256:504d127a567fef4f26c0ff61fd3ce8637ca766a3047e5fbb15bdbe45982c5d51"
+            "image": "registry.redhat.io/dynamic-accelerator-slicer-tech-preview/instaslice-daemonset-rhel9@sha256:747e20def6983648e509fd76ab40a6aef57c4e49dcb619d4f6a4f1f531121758"
         },
         {
             "name": "",
-            "image": "registry.redhat.io/dynamic-accelerator-slicer-tech-preview/instaslice-operator-bundle@sha256:309de603ad4198f14331639d22e462e81499870b18a4550308c97ac34af3bf3f"
+            "image": "registry.redhat.io/dynamic-accelerator-slicer-tech-preview/instaslice-operator-bundle@sha256:38c2a4e3a437a64bc88e059b3229890432cc7945377e8b943a6e9cb835a82bdf"
         },
         {
             "name": "",
-            "image": "registry.redhat.io/dynamic-accelerator-slicer-tech-preview/instaslice-rhel9-operator@sha256:814ac0501733d971084ae29559132d582adb02736421bd9a97df740976c97896"
+            "image": "registry.redhat.io/dynamic-accelerator-slicer-tech-preview/instaslice-rhel9-operator@sha256:c588c7a1612c944e8b95b3d166c1de46d100fb16ae95641121ddb07fade541a7"
         },
         {
             "name": "scheduler-image",
-            "image": "registry.redhat.io/dynamic-accelerator-slicer-tech-preview/instaslice-scheduler-rhel9@sha256:18aa9abe5d4e705ee6b2b92e96fa5577da8fa3f92d4220c0eaff212ae432198d"
+            "image": "registry.redhat.io/dynamic-accelerator-slicer-tech-preview/instaslice-scheduler-rhel9@sha256:bfa2529142093b7dcd38dea004807b6836650984b50320c3ee15ebe575123bb3"
         },
         {
             "name": "webhook-image",
-            "image": "registry.redhat.io/dynamic-accelerator-slicer-tech-preview/instaslice-webhook-rhel9@sha256:aa78424131f2795cb5c70e3247e0b376f225d26c1c64a6c9dd546f2f7d2616f0"
+            "image": "registry.redhat.io/dynamic-accelerator-slicer-tech-preview/instaslice-webhook-rhel9@sha256:828bc644e73a656625b9cd9bcaadfa35e5a6c84ce02848f2e7cfc93a1828fabc"
         }
     ]
 }

--- a/v4.19/catalog-template.yaml
+++ b/v4.19/catalog-template.yaml
@@ -3,4 +3,4 @@ GenerateMajorChannels: true
 GenerateMinorChannels: false
 Stable:
   Bundles:
-  - Image: registry.redhat.io/dynamic-accelerator-slicer-tech-preview/instaslice-operator-bundle@sha256:309de603ad4198f14331639d22e462e81499870b18a4550308c97ac34af3bf3f
+  - Image: registry.redhat.io/dynamic-accelerator-slicer-tech-preview/instaslice-operator-bundle@sha256:38c2a4e3a437a64bc88e059b3229890432cc7945377e8b943a6e9cb835a82bdf

--- a/v4.19/catalog/instaslice-operator/catalog.json
+++ b/v4.19/catalog/instaslice-operator/catalog.json
@@ -17,7 +17,7 @@
     "schema": "olm.bundle",
     "name": "das-operator.v0.1.0",
     "package": "das-operator",
-    "image": "registry.redhat.io/dynamic-accelerator-slicer-tech-preview/instaslice-operator-bundle@sha256:309de603ad4198f14331639d22e462e81499870b18a4550308c97ac34af3bf3f",
+    "image": "registry.redhat.io/dynamic-accelerator-slicer-tech-preview/instaslice-operator-bundle@sha256:38c2a4e3a437a64bc88e059b3229890432cc7945377e8b943a6e9cb835a82bdf",
     "properties": [
         {
             "type": "olm.gvk",
@@ -57,8 +57,8 @@
                     "alm-examples": "[\n  {\n    \"apiVersion\": \"inference.redhat.com/v1alpha1\",\n    \"kind\": \"DASOperator\",\n    \"metadata\": {\n      \"name\": \"cluster\",\n      \"namespace\": \"das-operator\"\n    },\n    \"spec\": {\n      \"logLevel\": \"Normal\",\n      \"managementState\": \"Managed\",\n      \"operatorLogLevel\": \"Normal\"\n    }\n  }\n]",
                     "capabilities": "Basic Install",
                     "categories": "Drivers and plugins",
-                    "containerImage": "registry.redhat.io/dynamic-accelerator-slicer-tech-preview/instaslice-rhel9-operator@sha256:814ac0501733d971084ae29559132d582adb02736421bd9a97df740976c97896",
-                    "createdAt": "2025-08-13T12:06:16Z",
+                    "containerImage": "registry.redhat.io/dynamic-accelerator-slicer-tech-preview/instaslice-rhel9-operator@sha256:c588c7a1612c944e8b95b3d166c1de46d100fb16ae95641121ddb07fade541a7",
+                    "createdAt": "2026-03-13T23:31:57Z",
                     "description": "Dynamic Accelerator Slicer works with GPU operator to create mig slices on demand",
                     "features.operators.openshift.io/cnf": "false",
                     "features.operators.openshift.io/cni": "false",
@@ -66,13 +66,13 @@
                     "features.operators.openshift.io/disconnected": "false",
                     "features.operators.openshift.io/fips-compliant": "false",
                     "features.operators.openshift.io/proxy-aware": "false",
-                    "features.operators.openshift.io/tls-profiles": "false",
+                    "features.operators.openshift.io/tls-profiles": "true",
                     "features.operators.openshift.io/token-auth-aws": "false",
                     "features.operators.openshift.io/token-auth-azure": "false",
                     "features.operators.openshift.io/token-auth-gcp": "false",
                     "operatorframework.io/suggested-namespace": "das-operator",
                     "operators.openshift.io/valid-subscription": "[\"OpenShift Kubernetes Engine\", \"OpenShift Container Platform\", \"OpenShift Platform Plus\"]",
-                    "operators.operatorframework.io/builder": "operator-sdk-v1.41.1",
+                    "operators.operatorframework.io/builder": "operator-sdk-unknown",
                     "operators.operatorframework.io/project_layout": "go.kubebuilder.io/v4",
                     "repository": "https://github.com/openshift/instaslice-operator",
                     "support": "https://github.com/openshift/instaslice-operator/issues"
@@ -83,21 +83,24 @@
                         {
                             "name": "dasoperators.inference.redhat.com",
                             "version": "v1alpha1",
-                            "kind": "DASOperator"
+                            "kind": "DASOperator",
+                            "description": "DASOperator is the schema for the DASOperator API"
                         },
                         {
                             "name": "allocationclaims.inference.redhat.com",
                             "version": "v1alpha1",
-                            "kind": "AllocationClaim"
+                            "kind": "AllocationClaim",
+                            "description": "AllocationClaim is the schema for GPU slice allocation custom resource."
                         },
                         {
                             "name": "nodeaccelerators.inference.redhat.com",
                             "version": "v1alpha1",
-                            "kind": "NodeAccelerator"
+                            "kind": "NodeAccelerator",
+                            "description": "NodeAccelerator is the schema for the nodeaccelerators API"
                         }
                     ]
                 },
-                "description": "### Introduction\nDynamic Accelerator Slicer uses stable APIs and works with GPU operator to create mig slices on demand.\n\n### Prerequisites\n\n1. Install the [NVIDIA GPU drivers and CUDA toolkit](https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html#driver-installation) on the host.\n2. Install the [NVIDIA Container Toolkit (CTK)](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html).\n3. Configure the NVIDIA Container Runtime as the default Docker runtime:\n      `sudo nvidia-ctk runtime configure --runtime=docker --set-as-default`\n4. Restart Docker to apply the changes:\n      `sudo systemctl restart docker`\n5. Configure the NVIDIA Container Runtime to use volume mounts to select devices to inject into a container:\n      `sudo nvidia-ctk config --set accept-nvidia-visible-devices-as-volume-mounts=true --in-place`\n      This sets accept-nvidia-visible-devices-as-volume-mounts=true in the /etc/nvidia-container-runtime/config.toml file\n6. Enable MIG on the GPU\n      Check if MIG is enabled on the host GPU - look for Enabled in the third row of the nvidia GPU table, while running `nvidia-smi`\n7. Create symlink in the control-plane container\n      `docker exec -ti kind-control-plane ln -s /sbin/ldconfig /sbin/ldconfig.real`\n8. Unmount the nvidia devices in the control-plane container\n      `docker exec -ti kind-control-plane umount -R /proc/driver/nvidia`\n9. Install the GPU Operator\n      `helm upgrade --install --wait gpu-operator -n gpu-operator --create-namespace nvidia/gpu-operator \\\n        --set mig.strategy=mixed \\\n        --set cdi.enabled=true \\\n        --set migManager.enabled=false \\\n        --set migManager.config.default=\"\"`\n10. Deploy cert manager\n      `kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.15.3/cert-manager.yaml`\n      \n### API Backward Compatibility\n**NOTE:**  Until Operator supports **seamless upgrades**, a new version of\nthe operator may introduce a change that is **NOT** backwards compatible with\nthe previous version. Thus, to upgrade the operator, uninstall the already\ninstalled version completely (including CRDs) and install the new version.\nFor example to upgrade from 0.1.0 to 0.2.0, you must uninstall `0.1.0` by\nfollowing [uninstall operator section](https://github.com/openshift/instaslice-operator)\nand install the new version.\n\nChanges to patch version (major.minor.patch) indicates that no breaking changes\nare introduced, thus upgrade can be done without uninstalling and reinstalling\nthe operator.\n\n### Why Dynamic Accelerator Slicer\n\nPartitionable accelerators provided by vendors need partition to be created at node boot-time or to change partitions one would have to evict all the workloads at the node level to create new set of partitions.\n\nDynamic Accelerator Slicer will help if:\n\n- user does not know all the accelerators partitions needed a priori on every node on the cluster\n\n- user partition requirements change at the workload level rather than the node level\n\n- user does not want to learn or use new API to request accelerators slices\n\n- user prefers to use stable device plugins APIs for creating partitions\n\n###Features Overview\n\n- Integration with Kubernetes [quota management](https://github.com/openshift/instaslice-operator/blob/main/docs/instaslice_kube_quota_int.md)\n\n- Integration with project [Kueue](https://github.com/openshift/instaslice-operator/blob/main/docs/kueue.md)\n\n- [Emulator](https://github.com/openshift/instaslice-operator/blob/main/docs/emulator.md) mode to run test Dynamic Accelerator Slicer firstfit placement strategy\n\n- Integration with vLLM, Kserve, [Deployments](https://github.com/openshift/instaslice-operator/blob/main/samples/vllm_deployment.yaml), [Jobs](https://github.com/openshift/instaslice-operator/blob/main/samples/vllm_job.yaml), and [Statefulsets](https://github.com/openshift/instaslice-operator/blob/main/samples/vllm_statefulset.yaml)\n\n### Documentation\nDocumentation and installation guide can be found below:\n  * [Installation Guide](https://github.com/openshift/instaslice-operator)\n  * [Dynamic Accelerator Slicer Operator](https://github.com/openshift/instaslice-operator/blob/main/README.md)\n\n### License\ndas-operator is licensed under the Apache 2.0 license",
+                "description": "### Introduction\nDynamic Accelerator Slicer uses stable APIs and works with the NVIDIA GPU Operator to create MIG slices on demand.\n\n### Why Dynamic Accelerator Slicer\n\nPartitionable accelerators provided by vendors need partition to be created at node boot-time or to change partitions one would have to evict all the workloads at the node level to create new set of partitions.\n\nDynamic Accelerator Slicer will help if:\n\n- user does not know all the accelerators partitions needed a priori on every node on the cluster\n- user partition requirements change at the workload level rather than the node level\n- user does not want to learn or use new API to request accelerators slices\n- user prefers to use stable device plugins APIs for creating partitions\n\n### Features\n- Integration with vLLM, Kserve, [Deployments](https://github.com/openshift/instaslice-operator/blob/main/samples/vllm_deployment.yaml), [Jobs](https://github.com/openshift/instaslice-operator/blob/main/samples/vllm_job.yaml), and [Statefulsets](https://github.com/openshift/instaslice-operator/blob/main/samples/vllm_statefulset.yaml)\n\n### Prerequisites\n\n1. Install the cert-manager Operator for Red Hat OpenShift.\n2. Install the Node Feature Discovery (NFD) Operator and create a NodeFeatureDiscovery custom resource so GPU labels are present on the cluster nodes.\n3. Install the NVIDIA GPU Operator and configure MIG support as described in the product documentation. At a minimum:\n   - Apply a ClusterPolicy that enables MIG mode and disables the default NVIDIA device plugin on nodes where you plan to create slices.\n   - Enable MIG on each GPU (verify with `nvidia-smi` and ensure the MIG column reports `Enabled`).\n   - Confirm the GPU Operator is healthy: `oc get clusterpolicies.nvidia.com -o jsonpath='{.items[0].status.state}'`.\n\nRefer to the OpenShift documentation for the full workflow: https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/html/hardware_accelerators/das-about-dynamic-accelerator-slicer-operator#das-operator-installing-web-console_das-about-dynamic-accelerator-slicer-operator.\n\n### API Backward Compatibility\n**NOTE:** Until Operator supports **seamless upgrades**, a new version of the operator may introduce a change that is **NOT** backwards compatible with the previous version. Thus, to upgrade the operator, uninstall the already installed version completely (including CRDs) and install the new version.\n\nFor example to upgrade from 0.1.0 to 0.2.0, you must uninstall `0.1.0` by following [uninstall operator section](https://github.com/openshift/instaslice-operator) and install the new version.\n\nChanges to patch version (major.minor.patch) indicates that no breaking changes are introduced, thus upgrade can be done without uninstalling and reinstalling the operator.\n\n### Documentation\nDocumentation and installation guide can be found below:\n  * [Dynamic Accelerator Slicer Operator](https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/html/hardware_accelerators/das-about-dynamic-accelerator-slicer-operator#das-operator-installing-web-console_das-about-dynamic-accelerator-slicer-operator)\n\n### License\ndas-operator is licensed under the Apache 2.0 license",
                 "displayName": "Dynamic Accelerator Slicer",
                 "installModes": [
                     {
@@ -181,23 +184,23 @@
     "relatedImages": [
         {
             "name": "daemonset-image",
-            "image": "registry.redhat.io/dynamic-accelerator-slicer-tech-preview/instaslice-daemonset-rhel9@sha256:504d127a567fef4f26c0ff61fd3ce8637ca766a3047e5fbb15bdbe45982c5d51"
+            "image": "registry.redhat.io/dynamic-accelerator-slicer-tech-preview/instaslice-daemonset-rhel9@sha256:747e20def6983648e509fd76ab40a6aef57c4e49dcb619d4f6a4f1f531121758"
         },
         {
             "name": "",
-            "image": "registry.redhat.io/dynamic-accelerator-slicer-tech-preview/instaslice-operator-bundle@sha256:309de603ad4198f14331639d22e462e81499870b18a4550308c97ac34af3bf3f"
+            "image": "registry.redhat.io/dynamic-accelerator-slicer-tech-preview/instaslice-operator-bundle@sha256:38c2a4e3a437a64bc88e059b3229890432cc7945377e8b943a6e9cb835a82bdf"
         },
         {
             "name": "",
-            "image": "registry.redhat.io/dynamic-accelerator-slicer-tech-preview/instaslice-rhel9-operator@sha256:814ac0501733d971084ae29559132d582adb02736421bd9a97df740976c97896"
+            "image": "registry.redhat.io/dynamic-accelerator-slicer-tech-preview/instaslice-rhel9-operator@sha256:c588c7a1612c944e8b95b3d166c1de46d100fb16ae95641121ddb07fade541a7"
         },
         {
             "name": "scheduler-image",
-            "image": "registry.redhat.io/dynamic-accelerator-slicer-tech-preview/instaslice-scheduler-rhel9@sha256:18aa9abe5d4e705ee6b2b92e96fa5577da8fa3f92d4220c0eaff212ae432198d"
+            "image": "registry.redhat.io/dynamic-accelerator-slicer-tech-preview/instaslice-scheduler-rhel9@sha256:bfa2529142093b7dcd38dea004807b6836650984b50320c3ee15ebe575123bb3"
         },
         {
             "name": "webhook-image",
-            "image": "registry.redhat.io/dynamic-accelerator-slicer-tech-preview/instaslice-webhook-rhel9@sha256:aa78424131f2795cb5c70e3247e0b376f225d26c1c64a6c9dd546f2f7d2616f0"
+            "image": "registry.redhat.io/dynamic-accelerator-slicer-tech-preview/instaslice-webhook-rhel9@sha256:828bc644e73a656625b9cd9bcaadfa35e5a6c84ce02848f2e7cfc93a1828fabc"
         }
     ]
 }

--- a/v4.20/catalog-template.yaml
+++ b/v4.20/catalog-template.yaml
@@ -3,4 +3,4 @@ GenerateMajorChannels: true
 GenerateMinorChannels: false
 Stable:
   Bundles:
-  - Image: registry.redhat.io/dynamic-accelerator-slicer-tech-preview/instaslice-operator-bundle@sha256:b789c76ceaa01e7f017c5eeecaeba9b7e76358e316e7f6595e97222a1e2d87f4
+  - Image: registry.redhat.io/dynamic-accelerator-slicer-tech-preview/instaslice-operator-bundle@sha256:38c2a4e3a437a64bc88e059b3229890432cc7945377e8b943a6e9cb835a82bdf

--- a/v4.20/catalog/instaslice-operator/catalog.json
+++ b/v4.20/catalog/instaslice-operator/catalog.json
@@ -17,7 +17,7 @@
     "schema": "olm.bundle",
     "name": "das-operator.v0.1.0",
     "package": "das-operator",
-    "image": "registry.redhat.io/dynamic-accelerator-slicer-tech-preview/instaslice-operator-bundle@sha256:b789c76ceaa01e7f017c5eeecaeba9b7e76358e316e7f6595e97222a1e2d87f4",
+    "image": "registry.redhat.io/dynamic-accelerator-slicer-tech-preview/instaslice-operator-bundle@sha256:38c2a4e3a437a64bc88e059b3229890432cc7945377e8b943a6e9cb835a82bdf",
     "properties": [
         {
             "type": "olm.gvk",
@@ -57,8 +57,8 @@
                     "alm-examples": "[\n  {\n    \"apiVersion\": \"inference.redhat.com/v1alpha1\",\n    \"kind\": \"DASOperator\",\n    \"metadata\": {\n      \"name\": \"cluster\",\n      \"namespace\": \"das-operator\"\n    },\n    \"spec\": {\n      \"logLevel\": \"Normal\",\n      \"managementState\": \"Managed\",\n      \"operatorLogLevel\": \"Normal\"\n    }\n  }\n]",
                     "capabilities": "Basic Install",
                     "categories": "Drivers and plugins",
-                    "containerImage": "registry.redhat.io/dynamic-accelerator-slicer-tech-preview/instaslice-rhel9-operator@sha256:24cc2fdb28108461f402327eac6e4d826f7e594cf42a77947824a15f39fdd5f0",
-                    "createdAt": "2025-09-19T20:10:57Z",
+                    "containerImage": "registry.redhat.io/dynamic-accelerator-slicer-tech-preview/instaslice-rhel9-operator@sha256:c588c7a1612c944e8b95b3d166c1de46d100fb16ae95641121ddb07fade541a7",
+                    "createdAt": "2026-03-13T23:31:57Z",
                     "description": "Dynamic Accelerator Slicer works with GPU operator to create mig slices on demand",
                     "features.operators.openshift.io/cnf": "false",
                     "features.operators.openshift.io/cni": "false",
@@ -72,7 +72,7 @@
                     "features.operators.openshift.io/token-auth-gcp": "false",
                     "operatorframework.io/suggested-namespace": "das-operator",
                     "operators.openshift.io/valid-subscription": "[\"OpenShift Kubernetes Engine\", \"OpenShift Container Platform\", \"OpenShift Platform Plus\"]",
-                    "operators.operatorframework.io/builder": "operator-sdk-v1.41.1",
+                    "operators.operatorframework.io/builder": "operator-sdk-unknown",
                     "operators.operatorframework.io/project_layout": "go.kubebuilder.io/v4",
                     "repository": "https://github.com/openshift/instaslice-operator",
                     "support": "https://github.com/openshift/instaslice-operator/issues"
@@ -184,23 +184,23 @@
     "relatedImages": [
         {
             "name": "daemonset-image",
-            "image": "registry.redhat.io/dynamic-accelerator-slicer-tech-preview/instaslice-daemonset-rhel9@sha256:0ba6b4f253731294d5d0ddc41ee4e8f385f64d900627bc66b239aab38fbc9c74"
+            "image": "registry.redhat.io/dynamic-accelerator-slicer-tech-preview/instaslice-daemonset-rhel9@sha256:747e20def6983648e509fd76ab40a6aef57c4e49dcb619d4f6a4f1f531121758"
         },
         {
             "name": "",
-            "image": "registry.redhat.io/dynamic-accelerator-slicer-tech-preview/instaslice-operator-bundle@sha256:b789c76ceaa01e7f017c5eeecaeba9b7e76358e316e7f6595e97222a1e2d87f4"
+            "image": "registry.redhat.io/dynamic-accelerator-slicer-tech-preview/instaslice-operator-bundle@sha256:38c2a4e3a437a64bc88e059b3229890432cc7945377e8b943a6e9cb835a82bdf"
         },
         {
             "name": "",
-            "image": "registry.redhat.io/dynamic-accelerator-slicer-tech-preview/instaslice-rhel9-operator@sha256:24cc2fdb28108461f402327eac6e4d826f7e594cf42a77947824a15f39fdd5f0"
+            "image": "registry.redhat.io/dynamic-accelerator-slicer-tech-preview/instaslice-rhel9-operator@sha256:c588c7a1612c944e8b95b3d166c1de46d100fb16ae95641121ddb07fade541a7"
         },
         {
             "name": "scheduler-image",
-            "image": "registry.redhat.io/dynamic-accelerator-slicer-tech-preview/instaslice-scheduler-rhel9@sha256:7cd069c53765a923c4d7d7e33505cd9d945bbb048c278035eb5c4848675d1758"
+            "image": "registry.redhat.io/dynamic-accelerator-slicer-tech-preview/instaslice-scheduler-rhel9@sha256:bfa2529142093b7dcd38dea004807b6836650984b50320c3ee15ebe575123bb3"
         },
         {
             "name": "webhook-image",
-            "image": "registry.redhat.io/dynamic-accelerator-slicer-tech-preview/instaslice-webhook-rhel9@sha256:b7f0235f3af7ec31b821425c42a7c9154a420f731dd5bc9a9209d630bbba11a3"
+            "image": "registry.redhat.io/dynamic-accelerator-slicer-tech-preview/instaslice-webhook-rhel9@sha256:828bc644e73a656625b9cd9bcaadfa35e5a6c84ce02848f2e7cfc93a1828fabc"
         }
     ]
 }

--- a/v4.21/catalog-template.yaml
+++ b/v4.21/catalog-template.yaml
@@ -3,4 +3,4 @@ GenerateMajorChannels: true
 GenerateMinorChannels: false
 Stable:
   Bundles:
-  - Image: registry.redhat.io/dynamic-accelerator-slicer-tech-preview/instaslice-operator-bundle@sha256:309de603ad4198f14331639d22e462e81499870b18a4550308c97ac34af3bf3f
+  - Image: registry.redhat.io/dynamic-accelerator-slicer-tech-preview/instaslice-operator-bundle@sha256:38c2a4e3a437a64bc88e059b3229890432cc7945377e8b943a6e9cb835a82bdf

--- a/v4.21/catalog/instaslice-operator/catalog.json
+++ b/v4.21/catalog/instaslice-operator/catalog.json
@@ -17,7 +17,7 @@
     "schema": "olm.bundle",
     "name": "das-operator.v0.1.0",
     "package": "das-operator",
-    "image": "registry.redhat.io/dynamic-accelerator-slicer-tech-preview/instaslice-operator-bundle@sha256:309de603ad4198f14331639d22e462e81499870b18a4550308c97ac34af3bf3f",
+    "image": "registry.redhat.io/dynamic-accelerator-slicer-tech-preview/instaslice-operator-bundle@sha256:38c2a4e3a437a64bc88e059b3229890432cc7945377e8b943a6e9cb835a82bdf",
     "properties": [
         {
             "type": "olm.gvk",
@@ -57,8 +57,8 @@
                     "alm-examples": "[\n  {\n    \"apiVersion\": \"inference.redhat.com/v1alpha1\",\n    \"kind\": \"DASOperator\",\n    \"metadata\": {\n      \"name\": \"cluster\",\n      \"namespace\": \"das-operator\"\n    },\n    \"spec\": {\n      \"logLevel\": \"Normal\",\n      \"managementState\": \"Managed\",\n      \"operatorLogLevel\": \"Normal\"\n    }\n  }\n]",
                     "capabilities": "Basic Install",
                     "categories": "Drivers and plugins",
-                    "containerImage": "registry.redhat.io/dynamic-accelerator-slicer-tech-preview/instaslice-rhel9-operator@sha256:814ac0501733d971084ae29559132d582adb02736421bd9a97df740976c97896",
-                    "createdAt": "2025-08-13T12:06:16Z",
+                    "containerImage": "registry.redhat.io/dynamic-accelerator-slicer-tech-preview/instaslice-rhel9-operator@sha256:c588c7a1612c944e8b95b3d166c1de46d100fb16ae95641121ddb07fade541a7",
+                    "createdAt": "2026-03-13T23:31:57Z",
                     "description": "Dynamic Accelerator Slicer works with GPU operator to create mig slices on demand",
                     "features.operators.openshift.io/cnf": "false",
                     "features.operators.openshift.io/cni": "false",
@@ -66,13 +66,13 @@
                     "features.operators.openshift.io/disconnected": "false",
                     "features.operators.openshift.io/fips-compliant": "false",
                     "features.operators.openshift.io/proxy-aware": "false",
-                    "features.operators.openshift.io/tls-profiles": "false",
+                    "features.operators.openshift.io/tls-profiles": "true",
                     "features.operators.openshift.io/token-auth-aws": "false",
                     "features.operators.openshift.io/token-auth-azure": "false",
                     "features.operators.openshift.io/token-auth-gcp": "false",
                     "operatorframework.io/suggested-namespace": "das-operator",
                     "operators.openshift.io/valid-subscription": "[\"OpenShift Kubernetes Engine\", \"OpenShift Container Platform\", \"OpenShift Platform Plus\"]",
-                    "operators.operatorframework.io/builder": "operator-sdk-v1.41.1",
+                    "operators.operatorframework.io/builder": "operator-sdk-unknown",
                     "operators.operatorframework.io/project_layout": "go.kubebuilder.io/v4",
                     "repository": "https://github.com/openshift/instaslice-operator",
                     "support": "https://github.com/openshift/instaslice-operator/issues"
@@ -83,21 +83,24 @@
                         {
                             "name": "dasoperators.inference.redhat.com",
                             "version": "v1alpha1",
-                            "kind": "DASOperator"
+                            "kind": "DASOperator",
+                            "description": "DASOperator is the schema for the DASOperator API"
                         },
                         {
                             "name": "allocationclaims.inference.redhat.com",
                             "version": "v1alpha1",
-                            "kind": "AllocationClaim"
+                            "kind": "AllocationClaim",
+                            "description": "AllocationClaim is the schema for GPU slice allocation custom resource."
                         },
                         {
                             "name": "nodeaccelerators.inference.redhat.com",
                             "version": "v1alpha1",
-                            "kind": "NodeAccelerator"
+                            "kind": "NodeAccelerator",
+                            "description": "NodeAccelerator is the schema for the nodeaccelerators API"
                         }
                     ]
                 },
-                "description": "### Introduction\nDynamic Accelerator Slicer uses stable APIs and works with GPU operator to create mig slices on demand.\n\n### Prerequisites\n\n1. Install the [NVIDIA GPU drivers and CUDA toolkit](https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html#driver-installation) on the host.\n2. Install the [NVIDIA Container Toolkit (CTK)](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html).\n3. Configure the NVIDIA Container Runtime as the default Docker runtime:\n      `sudo nvidia-ctk runtime configure --runtime=docker --set-as-default`\n4. Restart Docker to apply the changes:\n      `sudo systemctl restart docker`\n5. Configure the NVIDIA Container Runtime to use volume mounts to select devices to inject into a container:\n      `sudo nvidia-ctk config --set accept-nvidia-visible-devices-as-volume-mounts=true --in-place`\n      This sets accept-nvidia-visible-devices-as-volume-mounts=true in the /etc/nvidia-container-runtime/config.toml file\n6. Enable MIG on the GPU\n      Check if MIG is enabled on the host GPU - look for Enabled in the third row of the nvidia GPU table, while running `nvidia-smi`\n7. Create symlink in the control-plane container\n      `docker exec -ti kind-control-plane ln -s /sbin/ldconfig /sbin/ldconfig.real`\n8. Unmount the nvidia devices in the control-plane container\n      `docker exec -ti kind-control-plane umount -R /proc/driver/nvidia`\n9. Install the GPU Operator\n      `helm upgrade --install --wait gpu-operator -n gpu-operator --create-namespace nvidia/gpu-operator \\\n        --set mig.strategy=mixed \\\n        --set cdi.enabled=true \\\n        --set migManager.enabled=false \\\n        --set migManager.config.default=\"\"`\n10. Deploy cert manager\n      `kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.15.3/cert-manager.yaml`\n      \n### API Backward Compatibility\n**NOTE:**  Until Operator supports **seamless upgrades**, a new version of\nthe operator may introduce a change that is **NOT** backwards compatible with\nthe previous version. Thus, to upgrade the operator, uninstall the already\ninstalled version completely (including CRDs) and install the new version.\nFor example to upgrade from 0.1.0 to 0.2.0, you must uninstall `0.1.0` by\nfollowing [uninstall operator section](https://github.com/openshift/instaslice-operator)\nand install the new version.\n\nChanges to patch version (major.minor.patch) indicates that no breaking changes\nare introduced, thus upgrade can be done without uninstalling and reinstalling\nthe operator.\n\n### Why Dynamic Accelerator Slicer\n\nPartitionable accelerators provided by vendors need partition to be created at node boot-time or to change partitions one would have to evict all the workloads at the node level to create new set of partitions.\n\nDynamic Accelerator Slicer will help if:\n\n- user does not know all the accelerators partitions needed a priori on every node on the cluster\n\n- user partition requirements change at the workload level rather than the node level\n\n- user does not want to learn or use new API to request accelerators slices\n\n- user prefers to use stable device plugins APIs for creating partitions\n\n###Features Overview\n\n- Integration with Kubernetes [quota management](https://github.com/openshift/instaslice-operator/blob/main/docs/instaslice_kube_quota_int.md)\n\n- Integration with project [Kueue](https://github.com/openshift/instaslice-operator/blob/main/docs/kueue.md)\n\n- [Emulator](https://github.com/openshift/instaslice-operator/blob/main/docs/emulator.md) mode to run test Dynamic Accelerator Slicer firstfit placement strategy\n\n- Integration with vLLM, Kserve, [Deployments](https://github.com/openshift/instaslice-operator/blob/main/samples/vllm_deployment.yaml), [Jobs](https://github.com/openshift/instaslice-operator/blob/main/samples/vllm_job.yaml), and [Statefulsets](https://github.com/openshift/instaslice-operator/blob/main/samples/vllm_statefulset.yaml)\n\n### Documentation\nDocumentation and installation guide can be found below:\n  * [Installation Guide](https://github.com/openshift/instaslice-operator)\n  * [Dynamic Accelerator Slicer Operator](https://github.com/openshift/instaslice-operator/blob/main/README.md)\n\n### License\ndas-operator is licensed under the Apache 2.0 license",
+                "description": "### Introduction\nDynamic Accelerator Slicer uses stable APIs and works with the NVIDIA GPU Operator to create MIG slices on demand.\n\n### Why Dynamic Accelerator Slicer\n\nPartitionable accelerators provided by vendors need partition to be created at node boot-time or to change partitions one would have to evict all the workloads at the node level to create new set of partitions.\n\nDynamic Accelerator Slicer will help if:\n\n- user does not know all the accelerators partitions needed a priori on every node on the cluster\n- user partition requirements change at the workload level rather than the node level\n- user does not want to learn or use new API to request accelerators slices\n- user prefers to use stable device plugins APIs for creating partitions\n\n### Features\n- Integration with vLLM, Kserve, [Deployments](https://github.com/openshift/instaslice-operator/blob/main/samples/vllm_deployment.yaml), [Jobs](https://github.com/openshift/instaslice-operator/blob/main/samples/vllm_job.yaml), and [Statefulsets](https://github.com/openshift/instaslice-operator/blob/main/samples/vllm_statefulset.yaml)\n\n### Prerequisites\n\n1. Install the cert-manager Operator for Red Hat OpenShift.\n2. Install the Node Feature Discovery (NFD) Operator and create a NodeFeatureDiscovery custom resource so GPU labels are present on the cluster nodes.\n3. Install the NVIDIA GPU Operator and configure MIG support as described in the product documentation. At a minimum:\n   - Apply a ClusterPolicy that enables MIG mode and disables the default NVIDIA device plugin on nodes where you plan to create slices.\n   - Enable MIG on each GPU (verify with `nvidia-smi` and ensure the MIG column reports `Enabled`).\n   - Confirm the GPU Operator is healthy: `oc get clusterpolicies.nvidia.com -o jsonpath='{.items[0].status.state}'`.\n\nRefer to the OpenShift documentation for the full workflow: https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/html/hardware_accelerators/das-about-dynamic-accelerator-slicer-operator#das-operator-installing-web-console_das-about-dynamic-accelerator-slicer-operator.\n\n### API Backward Compatibility\n**NOTE:** Until Operator supports **seamless upgrades**, a new version of the operator may introduce a change that is **NOT** backwards compatible with the previous version. Thus, to upgrade the operator, uninstall the already installed version completely (including CRDs) and install the new version.\n\nFor example to upgrade from 0.1.0 to 0.2.0, you must uninstall `0.1.0` by following [uninstall operator section](https://github.com/openshift/instaslice-operator) and install the new version.\n\nChanges to patch version (major.minor.patch) indicates that no breaking changes are introduced, thus upgrade can be done without uninstalling and reinstalling the operator.\n\n### Documentation\nDocumentation and installation guide can be found below:\n  * [Dynamic Accelerator Slicer Operator](https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/html/hardware_accelerators/das-about-dynamic-accelerator-slicer-operator#das-operator-installing-web-console_das-about-dynamic-accelerator-slicer-operator)\n\n### License\ndas-operator is licensed under the Apache 2.0 license",
                 "displayName": "Dynamic Accelerator Slicer",
                 "installModes": [
                     {
@@ -181,23 +184,23 @@
     "relatedImages": [
         {
             "name": "daemonset-image",
-            "image": "registry.redhat.io/dynamic-accelerator-slicer-tech-preview/instaslice-daemonset-rhel9@sha256:504d127a567fef4f26c0ff61fd3ce8637ca766a3047e5fbb15bdbe45982c5d51"
+            "image": "registry.redhat.io/dynamic-accelerator-slicer-tech-preview/instaslice-daemonset-rhel9@sha256:747e20def6983648e509fd76ab40a6aef57c4e49dcb619d4f6a4f1f531121758"
         },
         {
             "name": "",
-            "image": "registry.redhat.io/dynamic-accelerator-slicer-tech-preview/instaslice-operator-bundle@sha256:309de603ad4198f14331639d22e462e81499870b18a4550308c97ac34af3bf3f"
+            "image": "registry.redhat.io/dynamic-accelerator-slicer-tech-preview/instaslice-operator-bundle@sha256:38c2a4e3a437a64bc88e059b3229890432cc7945377e8b943a6e9cb835a82bdf"
         },
         {
             "name": "",
-            "image": "registry.redhat.io/dynamic-accelerator-slicer-tech-preview/instaslice-rhel9-operator@sha256:814ac0501733d971084ae29559132d582adb02736421bd9a97df740976c97896"
+            "image": "registry.redhat.io/dynamic-accelerator-slicer-tech-preview/instaslice-rhel9-operator@sha256:c588c7a1612c944e8b95b3d166c1de46d100fb16ae95641121ddb07fade541a7"
         },
         {
             "name": "scheduler-image",
-            "image": "registry.redhat.io/dynamic-accelerator-slicer-tech-preview/instaslice-scheduler-rhel9@sha256:18aa9abe5d4e705ee6b2b92e96fa5577da8fa3f92d4220c0eaff212ae432198d"
+            "image": "registry.redhat.io/dynamic-accelerator-slicer-tech-preview/instaslice-scheduler-rhel9@sha256:bfa2529142093b7dcd38dea004807b6836650984b50320c3ee15ebe575123bb3"
         },
         {
             "name": "webhook-image",
-            "image": "registry.redhat.io/dynamic-accelerator-slicer-tech-preview/instaslice-webhook-rhel9@sha256:aa78424131f2795cb5c70e3247e0b376f225d26c1c64a6c9dd546f2f7d2616f0"
+            "image": "registry.redhat.io/dynamic-accelerator-slicer-tech-preview/instaslice-webhook-rhel9@sha256:828bc644e73a656625b9cd9bcaadfa35e5a6c84ce02848f2e7cfc93a1828fabc"
         }
     ]
 }


### PR DESCRIPTION
Update bundle SHA for OCP 4.18-4.21 prod releases

Execute `./generate-fbc.sh`